### PR TITLE
enabling versions to install the version that was current at the time MRAN started

### DIFF
--- a/R/available.versions.R
+++ b/R/available.versions.R
@@ -77,8 +77,13 @@ available.versions <- function (pkgs) {
   df <- rbind(current_df,
               previous_df)
 
-  # add whether they are on MRAN
+  # add whether they were posted since the start of MRAN
   df$available <- as.Date(df$date) >= as.Date('2014-09-17')
+
+  # also find the most recent version before the start of MRAN
+  first_available <- min(which(as.Date(df$date) <= as.Date('2014-09-17')))
+
+  df$available[first_available] <- TRUE
 
   # wrap into a list
   ans <- list()

--- a/README.md
+++ b/README.md
@@ -96,5 +96,5 @@ of those packages for a given date. `checkpoint` doesn't provide
 `install.packages`-like functionality however, and that's what *versions* aims
 to do, by querying MRAN.
 
-As MRAN only goes back to 2014-09-17, *versions* can't install packages from
-before this date.
+As MRAN only goes back to 2014-09-17, *versions* can only install packages on or 
+after this date.


### PR DESCRIPTION
should fix #10
