### PR TITLE
Small bugfix to prevent available.versions crashing early

### DIFF
--- a/R/available.versions.R
+++ b/R/available.versions.R
@@ -80,11 +80,12 @@ available.versions <- function (pkgs) {
   df <- rbind(current_df,
               previous_df)
 
+  if (all(is.na(df$available))) stop(sprintf("'%s' does not appear to be a valid package name", pkg))
   # add whether they were posted since the start of MRAN
   df$available <- as.Date(df$date) >= as.Date('2014-09-17')
 
   # also find the most recent version before the start of MRAN
-  if (!all(is.na(df$available)) && !all(df$available)) {
+  if (!all(df$available)) {
 
     first_available <- min(which(as.Date(df$date) <= as.Date('2014-09-17')))
     df$available[first_available] <- TRUE

--- a/R/available.versions.R
+++ b/R/available.versions.R
@@ -84,7 +84,7 @@ available.versions <- function (pkgs) {
   df$available <- as.Date(df$date) >= as.Date('2014-09-17')
 
   # also find the most recent version before the start of MRAN
-  if (!all(df$available)) {
+  if (!all(is.na(df$available)) && !all(df$available)) {
 
     first_available <- min(which(as.Date(df$date) <= as.Date('2014-09-17')))
     df$available[first_available] <- TRUE


### PR DESCRIPTION
 when a version is not recognized.

* Alternative approach would be to have current_version return a 0-row data frame rather than a 1-row dataframe with NAs.
* The underlying issue is that all(NA) returns NA on a one-row dataset.