### PR TITLE
add user-overridable MRAN url

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,5 +23,5 @@ Description: Installs specified versions of R packages hosted on CRAN and
 License: BSD_3_clause + file LICENSE
 LazyData: TRUE
 BugReports: https://github.com/goldingn/versions/issues
-RoxygenNote: 5.0.1
+RoxygenNote: 6.0.1
 Suggests: testthat

--- a/R/install.dates.R
+++ b/R/install.dates.R
@@ -84,7 +84,7 @@ install.dates <- function (pkgs,
     status <- package_status(pkg)
 
     # define repository
-    repos <- paste0('https://cran.microsoft.com/snapshot/', date)
+    repos <- paste0(mran_url(), date)
 
     install.packages(pkgs = pkg,
                      lib = lib,

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -25,7 +25,7 @@ url_lines <- function (url) {
 
 # return the url for the latest date on an index page of dates
 # (by default the MRAN snappshot index page)
-latest_mran <- function (url = 'https://cran.microsoft.com/snapshot') {
+latest_mran <- function (url = mran_url()) {
 
   # get all full dates
   dates <- scrape_index_dates(url)
@@ -293,4 +293,10 @@ package_status <- function (pkg) {
 
   }
 
+}
+
+# user-overridable url for MRAN
+mran_url <- function (subpath = "snapshot/") {
+  base_url <- getOption("versions.mran", "https://cran.microsoft.com")
+  paste(base_url, subpath, sep = "/")
 }

--- a/R/versions-package.R
+++ b/R/versions-package.R
@@ -31,6 +31,12 @@
 #'  \item \code{\link{installed.versions}}
 #' }
 #'
+#' @details The URL for MRAN may change from time to time. As of \code{versions}
+#'   0.4, the URL is \url{https://cran.microsoft.com/snapshot}, and this is what
+#'   the package uses. If the MRAN server URL changes before \code{versions} can
+#'   be updated, users can point versions to the new URL via the option
+#'   'versions.mran'. Ie. \code{options(versions.mran = "<some/new/url>")}
+#'
 #' @docType package
 #'
 #' @importFrom utils install.packages download.file

--- a/man/available.versions.Rd
+++ b/man/available.versions.Rd
@@ -34,4 +34,3 @@ available.versions(c('checkpoint', 'devtools'))
 }
 
 }
-

--- a/man/install.dates.Rd
+++ b/man/install.dates.Rd
@@ -11,7 +11,7 @@ install.dates(pkgs, dates, lib, ...)
 downloaded and installed}
 
 \item{dates}{character or Date vector of the dates for which to install the
-latest versions of \code{pkgs}. If a data vector, it must be in the format
+latest versions of \code{pkgs}. If a character vector, it must be in the format
 'yyyy-mm-dd', e.g. '2014-09-17'. If this has the same length as \code{pkgs}
  versions will correspond to those packages. If this has length one
  the same version will be used for all packages. If it has any other
@@ -45,4 +45,3 @@ install.dates(c('checkpoint', 'devtools'), Sys.Date() - 1:2)
 
 }
 }
-

--- a/man/install.versions.Rd
+++ b/man/install.versions.Rd
@@ -40,4 +40,3 @@ install.versions(c('checkpoint', 'devtools'), c('0.3.3', '1.6.1'))
 
 }
 }
-

--- a/man/installed.versions.Rd
+++ b/man/installed.versions.Rd
@@ -35,4 +35,3 @@ installed.versions(c('stats', 'versions'))
 installed.versions(c('stats', 'versions', 'notapackage'))
 
 }
-

--- a/man/versions-package.Rd
+++ b/man/versions-package.Rd
@@ -35,6 +35,13 @@ The available functions are:
  \item \code{\link{installed.versions}}
 }
 }
+\details{
+The URL for MRAN may change from time to time. As of \code{versions}
+  0.4, the URL is \url{https://cran.microsoft.com/snapshot}, and this is what
+  the package uses. If the MRAN server URL changes before \code{versions} can
+  be updated, users can point versions to the new URL via the option
+  'versions.mran'. Ie. \code{options(versions.mran = "<some/new/url>")}
+}
 \examples{
 
 \dontrun{
@@ -55,4 +62,3 @@ install.dates('checkpoint', '2014-12-25')
 
 
 }
-


### PR DESCRIPTION
Same functionality, but `options("versions.mran")` is now checked for a user-override on the MRAN URL. This is mentioned in the package-level help page.