### PR TITLE
add Imports and Depends to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,8 +20,10 @@ Description: Installs specified versions of R packages hosted on CRAN and
     'checkpoint' doesn't provide install.packages-like functionality however, and
     that's what 'versions' aims to do, by querying MRAN. As MRAN only goes back to
     2014-09-17, 'versions' can't install packages archived before this date.
+Depends: R (>= 3.2.2)
+Imports: utils
+Suggests: testthat
 License: BSD_3_clause + file LICENSE
 LazyData: TRUE
 BugReports: https://github.com/goldingn/versions/issues
 RoxygenNote: 6.0.1
-Suggests: testthat


### PR DESCRIPTION
Nice package.  

This PR suggests a minor modification to the DESCRIPTION file.

I think it would be great to add `Imports` and `Depends` entries to the DESCRIPTION so that people can easily know the package is light-weighted and does not require many other packages installed from CRAN.  I had to check the NAMESPACE and found out it only require utils package (and base R of course).

As for the `Depends`, I just checked time of the first commit for this package (Sept. 2015) and put in the latest version of R at that time.  You may relax the requirement.  But it would be good to have one.  After all the package itself is about "versions".

Feel free to decline this PR if you find it unnecessary.