### PR TITLE
change version_to_date to return last known date

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -184,9 +184,13 @@ version_to_date <- function (pkgs, versions) {
           " package from source in the CRAN archives")
   }
 
-  # get the day *after* this version first appeared on CRAN, to use as the MRAN
-  # snapshot date (in case of atime difference issue)
-  date <- as.Date(df$date[idx]) + 1
+  # The following either grabs the most recent snapshot, or a snapshot of the
+  # last day a package was available.
+  if (idx == 1) {
+    date <- Sys.Date() - 2
+  } else {
+    date <- as.Date(df$date[idx - 1]) - 1
+  }
 
   # make sure this wasn't before the MRAN start date
   # we already checked it's available, so this must be before it was superceded


### PR DESCRIPTION
@goldingn, what do you think of this change to use the most recent date that a package is available? If you're OK with it, I don't find fixing tests. I wanted to get a dialogue going early. This addresses the reprex in #28. 