### PR TITLE
Define subpath through options

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -296,7 +296,8 @@ package_status <- function (pkg) {
 }
 
 # user-overridable url for MRAN
-mran_url <- function (subpath = "snapshot/") {
+mran_url <- function () {
   base_url <- getOption("versions.mran", "https://cran.microsoft.com")
+  subpath <- getOption("versions.subpath", "snapshot/")
   paste(base_url, subpath, sep = "/")
 }


### PR DESCRIPTION
I am trying to mirror MRAN using our local JFrog artifactory. However, the absence of list on https://MRAN.revolutionanalytics.com/ denies me from retrieving list of snapshots.

However, if I set https://MRAN.revolutionanalytics.com/snapshot/ I can get the listing under artifactory, but the install.versions then does not work.. 


